### PR TITLE
Add location bias and state filtering to Places Autocomplete API

### DIFF
--- a/app/api_client.py
+++ b/app/api_client.py
@@ -125,6 +125,7 @@ class ApiClient:
         params = {
             "input": input_text,
             "components": "country:us",
+            "locationbias": "rectangle:39.0,-75.6|41.4,-73.3",
             "key": self.api_key,
         }
         try:
@@ -134,10 +135,12 @@ class ApiClient:
             if status != "OK":
                 log.warning(f"Places API status: {status}, error: {data.get('error_message', 'none')}")
                 return {"predictions": [], "status": status, "error": data.get("error_message")}
+            allowed_states = ("NJ", "NY", "New Jersey", "New York")
             return {
                 "predictions": [
                     {"description": p["description"], "place_id": p["place_id"]}
                     for p in data.get("predictions", [])
+                    if any(state in p.get("description", "") for state in allowed_states)
                 ],
                 "status": "OK",
             }

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -147,8 +147,8 @@ class TestPlacesAutocomplete:
         mock_resp = Mock()
         mock_resp.json.return_value = {
             "predictions": [
-                {"description": "123 Main St", "place_id": "abc"},
-                {"description": "456 Oak Ave", "place_id": "def"},
+                {"description": "123 Main St, Fort Lee, NJ", "place_id": "abc"},
+                {"description": "456 Oak Ave, New York, NY", "place_id": "def"},
             ],
             "status": "OK",
         }
@@ -157,7 +157,7 @@ class TestPlacesAutocomplete:
         result = client.places_autocomplete("123 Main")
         assert result["status"] == "OK"
         assert len(result["predictions"]) == 2
-        assert result["predictions"][0]["description"] == "123 Main St"
+        assert result["predictions"][0]["description"] == "123 Main St, Fort Lee, NJ"
 
     @patch("api_client.requests.get")
     def test_handles_api_error_status(self, mock_get, client):

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -118,7 +118,7 @@ class TestPlacesAutocompleteEndpoint:
         mock_resp = Mock()
         mock_resp.json.return_value = {
             "predictions": [
-                {"description": "123 Main St", "place_id": "abc"},
+                {"description": "123 Main St, Fort Lee, NJ", "place_id": "abc"},
             ],
             "status": "OK",
         }


### PR DESCRIPTION
## Summary
Enhanced the Places Autocomplete API integration to focus results on the New York/New Jersey area by adding location bias parameters and filtering predictions to only include results from NY and NJ.

## Key Changes
- Added `locationbias` parameter to the Places API request with a rectangle bounding the NY/NJ region (coordinates: 39.0,-75.6 to 41.4,-73.3)
- Implemented client-side filtering to only return predictions containing "NJ", "NY", "New Jersey", or "New York" in the description
- Updated test fixtures to reflect more complete address descriptions that include city and state information
- Updated test assertions to validate the new filtering behavior

## Implementation Details
- The location bias is applied at the API request level to improve result relevance
- State filtering is applied as a secondary validation layer to ensure only NY/NJ results are returned to the client
- The filtering logic checks for both state abbreviations (NJ, NY) and full state names (New Jersey, New York) to handle various API response formats

https://claude.ai/code/session_019eGQMtQQD35mfgJDC7CzhL