### PR TITLE
Add bot traffic filtering to analytics middleware

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# CLAUDE.md
+
+## Project overview
+
+GWB Routes is a FastAPI app that shows real-time George Washington Bridge commute times (4 routes: upper/lower level, each direction). It includes a dashboard UI, route recommendations, historical tracking, and request analytics.
+
+Deployed as a Vercel serverless function. All HTTP routes map to `app/index.py`.
+
+## Architecture
+
+```
+app/
+  index.py          # FastAPI app, middleware, all route handlers
+  api_client.py     # Google Maps Directions/Places API wrapper
+  analytics.py      # Request logging + query methods (PostgreSQL)
+  database.py       # PostgreSQL connection (NeonDB) + schema init
+  history.py        # Historical route duration storage + aggregation
+  routes_cache.py   # Redis cache for API responses (180s TTL)
+  constants.py      # GWB route GPS coordinates
+  response_models.py # Pydantic response schemas
+static/
+  index.html        # Dashboard frontend (vanilla JS, dark theme)
+tests/              # pytest suite (mocked external deps)
+```
+
+**External services:** Google Maps API (required), NeonDB PostgreSQL (optional), Redis (optional), Sentry (optional). All optional services degrade gracefully.
+
+## Running tests
+
+```bash
+pip install -r requirements.txt
+pip install pytest httpx
+PYTHONPATH=app python -m pytest tests/ -v --tb=short
+```
+
+Tests mock all external APIs (Google Maps, database, Redis). No real credentials needed — set `GOOGLE_MAPS_API_KEY=test-key`.
+
+CI runs on push/PR to main via `.github/workflows/python-ci.yml`.
+
+## Key considerations
+
+- **NeonDB is on hobby tier (0.5 GB limit).** The analytics middleware filters bot traffic by user-agent to avoid bloating `request_logs`. If storage grows, consider adding TTL-based cleanup (e.g., `DELETE FROM request_logs WHERE timestamp < NOW() - INTERVAL '30 days'`).
+- **Google Maps API quota** is managed via Redis caching (3-min TTL) and Vercel edge cache headers.
+- **IP privacy:** IPs are SHA256-hashed before storage — never stored raw.
+- **Analytics endpoints** (`/analytics/*`) are excluded from logging to prevent feedback loops.
+- Environment variables: `GOOGLE_MAPS_API_KEY` (required), `DATABASE_URL`, `REDIS_URL`, `SENTRY_DSN` (all optional).

--- a/app/index.py
+++ b/app/index.py
@@ -1,4 +1,5 @@
 import os
+import re
 import time
 import logging
 from typing import Optional
@@ -63,12 +64,39 @@ log.info("Starting server...")
 
 ANALYTICS_SKIP_PATHS = {"/healthcheck", "/favicon.ico", "/analytics"}
 
+# Patterns that identify bot / crawler / non-human traffic.
+# Matched case-insensitively against the User-Agent header.
+_BOT_UA_PATTERN = re.compile(
+    r"bot|crawl|spider|slurp|bingpreview|mediapartners|facebookexternalhit"
+    r"|linkedinbot|twitterbot|whatsapp|telegrambot|discordbot|applebot"
+    r"|yandex|baidu|duckduckbot|sogou|exabot|semrush|ahrefs|mj12bot|dotbot"
+    r"|rogerbot|gigabot|ia_archiver|archive\.org_bot|httrack|wget|curl"
+    r"|python-requests|python-urllib|go-http-client|java/|perl|ruby"
+    r"|libwww|lwp-|httpunit|nutch|phpcrawl|biglotron|teoma|convera"
+    r"|gigablast|ia_archiver|webmon|htdig|grub|netresearchserver"
+    r"|speedy|fluffy|findlink|msrbot|panscient|yadirectfetcher"
+    r"|pingdom|uptimerobot|monitis|statuscake|site24x7"
+    r"|headlesschrome|phantomjs|puppeteer|playwright|selenium",
+    re.IGNORECASE,
+)
+
+
+def _is_bot(user_agent: Optional[str]) -> bool:
+    """Return True if the user-agent looks like a bot or automated client."""
+    if not user_agent:
+        return True  # No UA is almost certainly not a real browser
+    return _BOT_UA_PATTERN.search(user_agent) is not None
+
 
 @app.middleware("http")
 async def log_requests(request: Request, call_next):
     """Log every request to the analytics table."""
     # Skip logging for analytics/health endpoints to avoid feedback loops
     if any(request.url.path.startswith(p) for p in ANALYTICS_SKIP_PATHS):
+        return await call_next(request)
+
+    # Skip logging for bot / non-human traffic to conserve database storage
+    if _is_bot(request.headers.get("user-agent")):
         return await call_next(request)
 
     start = time.monotonic()

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -131,6 +131,45 @@ class TestPlacesAutocompleteEndpoint:
         assert len(data["predictions"]) == 1
 
 
+class TestBotFiltering:
+    def test_bot_user_agent_skips_analytics(self, test_client):
+        client, _ = test_client
+        with patch("index.analytics") as mock_analytics:
+            resp = client.get("/times", headers={"User-Agent": "Googlebot/2.1"})
+            assert resp.status_code == 200
+            mock_analytics.log_request.assert_not_called()
+
+    def test_real_user_agent_logs_analytics(self, test_client):
+        client, _ = test_client
+        with patch("index.analytics") as mock_analytics:
+            resp = client.get("/times", headers={
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+            })
+            assert resp.status_code == 200
+            mock_analytics.log_request.assert_called_once()
+
+    def test_empty_user_agent_skips_analytics(self, test_client):
+        client, _ = test_client
+        with patch("index.analytics") as mock_analytics:
+            resp = client.get("/times", headers={"User-Agent": ""})
+            assert resp.status_code == 200
+            mock_analytics.log_request.assert_not_called()
+
+    def test_curl_skips_analytics(self, test_client):
+        client, _ = test_client
+        with patch("index.analytics") as mock_analytics:
+            resp = client.get("/times", headers={"User-Agent": "curl/7.81.0"})
+            assert resp.status_code == 200
+            mock_analytics.log_request.assert_not_called()
+
+    def test_python_requests_skips_analytics(self, test_client):
+        client, _ = test_client
+        with patch("index.analytics") as mock_analytics:
+            resp = client.get("/times", headers={"User-Agent": "python-requests/2.28.0"})
+            assert resp.status_code == 200
+            mock_analytics.log_request.assert_not_called()
+
+
 class TestDashboard:
     def test_dashboard_root(self, test_client):
         client, _ = test_client


### PR DESCRIPTION
## Summary
Implement bot/crawler detection in the analytics middleware to prevent non-human traffic from bloating the NeonDB analytics table. This addresses storage concerns on the hobby tier (0.5 GB limit) by skipping analytics logging for automated clients.

## Changes
- **Bot detection pattern**: Added comprehensive regex pattern (`_BOT_UA_PATTERN`) that identifies common bots, crawlers, and automated HTTP clients (Googlebot, curl, python-requests, Selenium, Puppeteer, etc.)
- **Helper function**: Introduced `_is_bot()` to check User-Agent headers; treats missing/empty User-Agent as bot traffic
- **Middleware integration**: Updated `log_requests()` middleware to skip analytics logging when bot traffic is detected
- **Test coverage**: Added `TestBotFiltering` class with 5 test cases covering:
  - Bot user-agents (Googlebot, curl, python-requests)
  - Empty/missing User-Agent headers
  - Real browser user-agents (should still log)
- **Documentation**: Added CLAUDE.md with project overview, architecture, testing instructions, and key considerations including this bot filtering strategy

## Implementation Details
- Bot detection is case-insensitive and matches against 40+ known bot/crawler/tool patterns
- Filtering happens early in the middleware stack (after path-based skips) to minimize overhead
- No changes to response behavior—bots receive normal responses, just aren't logged
- Graceful degradation: if User-Agent header is missing, traffic is treated as bot (conservative approach to preserve storage)

https://claude.ai/code/session_01YHhVGpGzZekb5TaRP32KCr