### PR TITLE
Add Microsoft Clarity analytics tracking support

### DIFF
--- a/app/index.py
+++ b/app/index.py
@@ -118,6 +118,21 @@ async def dashboard(response: Response):
             html_content = f.read()
         # Replace localhost:8000 with relative URLs for production
         html_content = html_content.replace('"http://localhost:8000"', '""')
+        # Inject Microsoft Clarity tracking if configured
+        clarity_id = os.environ.get("CLARITY_PROJECT_ID", "")
+        if clarity_id:
+            clarity_script = (
+                '<script type="text/javascript">'
+                "(function(c,l,a,r,i,t,y){"
+                "c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};"
+                "t=l.createElement(r);t.async=1;t.src=\"https://www.clarity.ms/tag/\"+i;"
+                "y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);"
+                f"}})(window, document, \"clarity\", \"script\", \"{clarity_id}\");"
+                "</script>"
+            )
+            html_content = html_content.replace("<!-- __CLARITY_SCRIPT__ -->", clarity_script)
+        else:
+            html_content = html_content.replace("<!-- __CLARITY_SCRIPT__ -->", "")
         # Cache for 10 minutes - longer than data cache but not too long for UI updates
         response.headers["Cache-Control"] = "public, max-age=600, s-maxage=600"
         metrics.count("dashboard.request", 1)

--- a/static/index.html
+++ b/static/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>GWB Routes - Real-time Traffic</title>
+    <!-- __CLARITY_SCRIPT__ -->
     <style>
       * {
         margin: 0;


### PR DESCRIPTION
## Summary
This PR adds optional Microsoft Clarity analytics tracking to the dashboard by injecting the Clarity tracking script when configured via environment variable.

## Key Changes
- Added `CLARITY_PROJECT_ID` environment variable support to conditionally enable Microsoft Clarity tracking
- Implemented dynamic script injection in the dashboard HTML response that:
  - Reads the Clarity project ID from environment configuration
  - Generates and injects the official Clarity tracking script if configured
  - Removes the placeholder comment if no project ID is set
- Added `<!-- __CLARITY_SCRIPT__ -->` placeholder in the HTML template for script injection point

## Implementation Details
- The Clarity script is injected server-side during the dashboard response generation, allowing for environment-based configuration without modifying static assets
- The implementation uses the official Clarity initialization code pattern
- When `CLARITY_PROJECT_ID` is not set or empty, the placeholder is simply removed, resulting in no tracking overhead
- The script injection happens after the localhost URL replacement, maintaining the existing response processing pipeline

https://claude.ai/code/session_019c4LQHuFjafMdV9iMz5Sos